### PR TITLE
Johansmacias/improvements for at commands interface

### DIFF
--- a/src/at_cmd.cpp
+++ b/src/at_cmd.cpp
@@ -1012,6 +1012,11 @@ static void at_cmd_handle(void)
 void at_serial_input(uint8_t cmd)
 {
 	Serial.printf("%c", cmd);
+	if (cmd == '\b')
+	{
+		atcmd[atcmd_index--] = '\0';
+		Serial.printf(" \b");
+	}
 
 	if ((cmd >= '0' && cmd <= '9') || (cmd >= 'a' && cmd <= 'z') ||
 		(cmd >= 'A' && cmd <= 'Z') || cmd == '?' || cmd == '+' || cmd == ':' ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,6 @@ void loop()
 			if ((g_task_event_type & AT_CMD) == AT_CMD)
 			{
 				g_task_event_type &= N_AT_CMD;
-				MYLOG("APP", "USB data received");
 
 				while (Serial.available() > 0)
 				{
@@ -208,7 +207,11 @@ void loop()
 				}
 			}
 		}
-		MYLOG("MAIN", "Loop goes to sleep");
+		// Skip this log message when USB data is received
+		if ((g_task_event_type & AT_CMD) == AT_CMD)
+		{
+			MYLOG("MAIN", "Loop goes to sleep");
+		}
 		Serial.flush();
 		g_task_event_type = 0;
 		// Go back to sleep


### PR DESCRIPTION
When the debug output is enabled could be a good idea to hide the messages related to the USB to avoid the following behavior while entering AT commands.

![Improvements AT serial interface 01](https://user-images.githubusercontent.com/50062162/134717297-1609cd12-7e7f-491c-843f-87044ea2b87d.gif)

Currently, when entering the AT commands we cannot correct any character. If we make a mistake backspace doesn't clear the _atcmd_ buffer and the serial keeps showing all the entered characters. These are the improvements to achieve it:
- The buffer modifications when pressing backspace involve decreasing the _atcmd_index_ and clearing the character.
- To clean up the serial output print the space character, and a new backspace.

The final result.
![Improvements AT serial interface 02](https://user-images.githubusercontent.com/50062162/134719493-9cbfc848-f63a-4b17-a6ae-6bb61ddd60d3.gif)


