### PR TITLE
Johansmacias/default settings modifications

### DIFF
--- a/src/WisBlock-API.h
+++ b/src/WisBlock-API.h
@@ -164,7 +164,10 @@ void lora_data_handler(void);
 
 void api_set_version(uint16_t sw_1 = 1, uint16_t sw_2 = 0, uint16_t sw_3 = 0);
 void api_set_credentials(void);
+void api_enable_default_settings_modifications(void);
 extern bool g_fix_credentials;
+extern bool g_is_enabled_default_settings_modifications;
+extern s_lorawan_settings g_default_settings_modified;
 extern uint16_t g_sw_ver_1; // major version increase on API change / not backwards compatible
 extern uint16_t g_sw_ver_2; // minor version increase on API change / backward compatible
 extern uint16_t g_sw_ver_3; // patch version increase on bugfix, no affect on API

--- a/src/api_settings.cpp
+++ b/src/api_settings.cpp
@@ -17,6 +17,8 @@ uint16_t g_sw_ver_2 = 0; // minor version increase on API change / backward comp
 uint16_t g_sw_ver_3 = 0; // patch version increase on bugfix, no affect on API
 
 bool g_fix_credentials = false;
+bool g_is_enabled_default_settings_modifications = false;
+s_lorawan_settings g_default_settings_modified;
 
 /**
  * @brief Set application version
@@ -39,6 +41,16 @@ void api_set_version(uint16_t sw_1, uint16_t sw_2, uint16_t sw_3)
 void api_set_credentials(void)
 {
 	g_fix_credentials = true;
+}
+
+/**
+ * @brief Inform API modifications in the default_settings to apply when a
+ * flash_reset() is performed.
+ * 
+ */
+void api_enable_default_settings_modifications(void)
+{
+	g_is_enabled_default_settings_modifications = true;
 }
 
 #endif

--- a/src/flash.cpp
+++ b/src/flash.cpp
@@ -116,6 +116,10 @@ void flash_reset(void)
 		if (lora_file.open(settings_name, FILE_O_WRITE))
 		{
 			s_lorawan_settings default_settings;
+			if (g_is_enabled_default_settings_modifications)
+			{
+				default_settings = g_default_settings_modified;
+			}
 			lora_file.write((uint8_t *)&default_settings, sizeof(s_lorawan_settings));
 			lora_file.flush();
 			lora_file.close();


### PR DESCRIPTION
When the definition of the `s_lorawan_settings` structure was in the project files (main.h before WisBlock API), I could modify it to achieve a different default configuration when the flash is reset. I mean the first time a previous configuration file doesn't exist in flash, or a reboot with the ATR command is performed. 

I think it is convenient to allow modifications on these default settings according to the project requirements. To mention two scenarios:

- When flashing firmware for several devices, I would like to modify only the LoRaWAN credentials and use a new default configuration to preset the send_repeat_time, the lora_region, or any other parameter. Otherwise, I always need to use the AT commands or the App to change those values.

- Sometimes, a network server requires a  different subband selection. For instance, subband 2 is the one used/recommended in TTN or Helium for several regions. Currently, there's no AT command to change this, and the only option is in the App.

Since the `api_set_credentials()` is intended for hardcoding the parameters and ignores any other interaction from flash I didn't consider it suitable for this purpose. However, my suggestion is based on a similar approach that I called `api_enable_default_settings_modifications()`.

Example:
```
void setup_app(void)
{
	g_enable_ble = true;

	// Optional default settings modifications
	g_default_settings_modified.lora_region = 8;            // US915 region
	g_default_settings_modified.subband_channels = 2;       // Subband 2
	g_default_settings_modified.send_repeat_time = 300000;  // 5 minutes
	// Inform API modifications in the default_settings
	api_enable_default_settings_modifications();

}
```