### PR TITLE
Keep the saved region after receiving config from My-nRF52-Toolbox

### DIFF
--- a/src/ble.cpp
+++ b/src/ble.cpp
@@ -217,6 +217,8 @@ void settings_rx_callback(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *da
 	// Check the characteristic
 	if (chr->uuid == g_lora_data.uuid)
 	{
+		uint8_t keep_lora_region; // To keep the saved value after receiving config from My-nRF52-Toolbox
+
 		if (len != sizeof(s_lorawan_settings))
 		{
 			MYLOG("SETT", "Received settings have wrong size %d", len);
@@ -230,8 +232,12 @@ void settings_rx_callback(uint16_t conn_hdl, BLECharacteristic *chr, uint8_t *da
 			return;
 		}
 
+		keep_lora_region = g_lorawan_settings.lora_region;
+
 		// Save new LoRa settings
 		memcpy((void *)&g_lorawan_settings, data, sizeof(s_lorawan_settings));
+
+		g_lorawan_settings.lora_region = keep_lora_region;
 
 		// Save new settings
 		save_settings();


### PR DESCRIPTION
Every time a new configuration is received over BLE from My-nRF52-Toolbox the `lora_region` is overwritten with the option 0. I propose a workaround while this is solved from the My-nRF52-Toolbox side.