### PR TITLE
Update at_cmd.cpp

### DIFF
--- a/src/at_cmd.cpp
+++ b/src/at_cmd.cpp
@@ -373,10 +373,10 @@ static int at_exec_p2p_txp(char *str)
 
 static int at_query_p2p_config(void)
 {
-	snprintf(g_at_query_buf, ATQUERY_SIZE, "%ld:%d:%d:%d:%d:%d",
+	snprintf(g_at_query_buf, ATQUERY_SIZE, "%ld:%d:%s:%d:%d:%d",
 			 g_lorawan_settings.p2p_frequency,
 			 g_lorawan_settings.p2p_sf,
-			 g_lorawan_settings.p2p_bandwidth,
+			 bandwidths[g_lorawan_settings.p2p_bandwidth],
 			 g_lorawan_settings.p2p_cr,
 			 g_lorawan_settings.p2p_preamble_len,
 			 g_lorawan_settings.p2p_tx_power);


### PR DESCRIPTION
Updated the `at_query_p2p_config()` function so that the string displays the exact same configuration string as what the user sends. Right now, we pass BW as "125" for instance, but the query function sends back "0":

```
AT+P2P=868000000:10:**125**:1:8:22
OK
AT+P2P=?
+P2P:868000000:10:**0**:1:8:22
OK
```

I think it's better to output the same thing the user sends.